### PR TITLE
Added .cfignore and manifest for CF

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,8 @@
+node_modules/
+*.DS_Store
+README.md
+.github/
+.git/
+.gitignore
+logs
+*.log

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const randomize = require('randomatic');
 const genreRouter = require('./routes/genreRoute');
 const gameListRouter = require('./routes/gameListRoute');
 const cors = require('cors');
-const port = 3000;
+//const port = 3000;
+const port = 8080;
 
 // static files for use in page
 app.use(express.static(__dirname +'/public'));
@@ -15,7 +16,6 @@ app.use(express.urlencoded({ extended: true }))
 app.use(cors());
 
 // ROUTES 
-
 
 app.use('/api/genreList', genreRouter);
 app.use('/api/gameList', gameListRouter);

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,4 @@
+applications:
+- name: Gawi Meki
+  random-route: true
+  memory: 2656M

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -192,6 +201,21 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is-number": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -235,6 +259,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -266,6 +295,16 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      }
     },
     "range-parser": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "DASW project for Fall 2020",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -26,7 +27,9 @@
   "homepage": "https://github.com/OverripeWings3/DASWProject#readme",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
+    "randomatic": "^3.1.1",
     "yes": "^1.1.1"
   }
 }


### PR DESCRIPTION
This adds functionality for the Cloud Foundry. [HERE](https://gawi-meki-timely-wildebeest-vr.mybluemix.net/) is the app. As with github, it needs to be continually pushed to have the latest version of the page. However, we should only push from main branch and not from any other branch. This is to maintain the latest stable version without breaking it.

We encountered some errors while doing this (FYI in case another person encounters the same):
- saying the start script wasn't there. This means you need to add it in the nodejs "package.json".
- Some npm packages weren't installed (i.e, cors)
- It failed to make a TCP connection. The way to fix it is to change the port to 8080, otherwise, the app won't listen.
